### PR TITLE
fix: devenv apple-sdk

### DIFF
--- a/devenv/bazel/devenv.nix
+++ b/devenv/bazel/devenv.nix
@@ -5,25 +5,19 @@
   inputs,
   brainhive,
   ...
-}:
-
-let
+}: let
   brain = brainhive.packages.${pkgs.system};
-  apple-sdk' = brain.apple-sdk.override {
+  apple-sdk = brain.apple-sdk.override {
     extraLibraries = with pkgs.darwin; [
       libiconv
       libresolv
     ];
   };
-in
-{
+in {
   packages = [
-    # apple-sdk'
     brain.bazelisk
+    apple-sdk
   ];
 
-  apple.sdk = null;
-
-  # env.DEVELOPER_DIR = "${apple-sdk'}";
-  # env.SDKROOT = "${apple-sdk'}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
+  apple.sdk = apple-sdk;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,12 @@
         packages = self.packages.${prev.system};
       in {
         brain = {
-          inherit (packages) aptakube bazelisk;
+          inherit
+            (packages)
+            aptakube
+            bazelisk
+            apple-sdk
+            ;
           mkSdkShell = prev.callPackage ./pkgs/sdk-shell.nix {inherit (packages) apple-sdk;};
         };
       };

--- a/pkgs/apple-sdk.nix
+++ b/pkgs/apple-sdk.nix
@@ -1,29 +1,21 @@
 {
   lib,
   darwin,
-  symlinkJoin,
   apple-sdk_15,
   package ? apple-sdk_15,
   extraLibraries ? [],
 }:
-symlinkJoin {
-  inherit (package) pname version meta;
-
-  paths = [package];
-
-  buildInputs = [darwin.libtapi];
-
-  postBuild = let
+package.overrideAttrs {
+  postInstall = let
     mkStub = dylib:
     # sh
     ''
-      tapi stubify "${dylib}/lib/${dylib.pname}.dylib" -o "$library_path/${dylib.pname}.tbd"
+      ${lib.getExe darwin.libtapi} stubify "${dylib}/lib/${dylib.pname}.dylib" -o "$library_path/${dylib.pname}.tbd"
     '';
   in
     # sh
     ''
       library_path="$out/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${package.version}.sdk/usr/lib"
-      mkdir -p $library_path
       ${lib.concatStringsSep "\n" (map mkStub extraLibraries)}
     '';
 }


### PR DESCRIPTION
This fixes our problems with the apple-sdk for now, though it does require building it from source which does take some time.

After this has been merged we have to manually update the lockfile before it can actually work as intented.

Might also be worth seeing if we can use devenv with flakes so we don't have seperate lockfiles for everything